### PR TITLE
Patches for SnowMelt and high-latitude PotentialSolar

### DIFF
--- a/R/PotentialSolar.R
+++ b/R/PotentialSolar.R
@@ -8,6 +8,9 @@ function(lat,Jday){
 # solar declination [rad]
 dec<-declination(Jday)
 
-return(117500*(acos(-tan(dec)*tan(lat))*sin(lat)*sin(dec)+cos(lat)*cos(dec)*sin(acos(tan(dec)*tan(lat))))/pi)
+out<-117500*(acos(-tan(dec)*tan(lat))*sin(lat)*sin(dec)+cos(lat)*cos(dec)*sin(acos(tan(dec)*tan(lat))))/pi
+if (is.na(out)) out <- 0
+
+return(out)
 }
 

--- a/R/PotentialSolar.R
+++ b/R/PotentialSolar.R
@@ -8,9 +8,10 @@ function(lat,Jday){
 # solar declination [rad]
 dec<-declination(Jday)
 
-out<-117500*(acos(-tan(dec)*tan(lat))*sin(lat)*sin(dec)+cos(lat)*cos(dec)*sin(acos(tan(dec)*tan(lat))))/pi
-if (is.na(out)) out <- 0
-
-return(out)
+if (abs(-tan(dec)*tan(lat))-1 < 0){
+  return(117500*(acos(-tan(dec)*tan(lat))*sin(lat)*sin(dec)+cos(lat)*cos(dec)*sin(acos(tan(dec)*tan(lat))))/pi)
+} else {
+  return(0)
+}
 }
 

--- a/R/SnowMelt.R
+++ b/R/SnowMelt.R
@@ -50,7 +50,7 @@ SnowMelt<-function(Date, precip_mm, Tmax_C, Tmin_C, lat_deg, slope=0, aspect=0, 
 	SnowWaterEq[1] 	<- startingSnowDepth_m * startingSnowDensity_kg_m3 / WaterDens		
 	SnowDepth[1] 	<- startingSnowDepth_m			
 	Albedo[1] <- ifelse(NewSnow[1] > 0, 0.98-(0.98-0.50)*exp(-4*NewSnow[1]*10),ifelse(startingSnowDepth_m == 0, groundAlbedo, max(groundAlbedo, 0.5+(groundAlbedo-0.85)/10)))  # If snow on the ground or new snow, assume Albedo yesterday was 0.5
-	S[1] <- Solar(lat=lat,Jday=JDay[1], Tx=Tmax_C[1], Tn=Tmin_C[1], albedo=Albedo[1], forest=forest, aspect=aspect, slope=slope)
+	S[1] <- Solar(lat=lat,Jday=JDay[1], Tx=Tmax_C[1], Tn=Tmin_C[1], albedo=Albedo[1], forest=forest, aspect=aspect, slope=slope, latUnits="radians")
 	H[1] <- 1.29*(Tav[1]-SnowTemp[1])/rh[1] 
 	E[1] <- lambdaV*(rhoa[1]-rhos[1])/rh[1]
 	if(startingSnowDepth_m>0) TE[1] <- 0.97 
@@ -72,7 +72,7 @@ SnowMelt<-function(Date, precip_mm, Tmax_C, Tmin_C, lat_deg, slope=0, aspect=0, 
 			Albedo[i] <- max(groundAlbedo, Albedo[i-1]+(groundAlbedo-0.85)/10)
 		} else Albedo[i] <- 0.35-(0.35-0.98)*exp(-1*(0.177+(log((-0.3+0.98)/(Albedo[i-1]-0.3)))^2.16)^0.46)
 
-		S[i] <- Solar(lat=lat,Jday=JDay[i], Tx=Tmax_C[i], Tn=Tmin_C[i], albedo=Albedo[i-1], forest=forest, aspect=aspect, slope=slope, printWarn=FALSE)
+		S[i] <- Solar(lat=lat,Jday=JDay[i], Tx=Tmax_C[i], Tn=Tmin_C[i], albedo=Albedo[i-1], forest=forest, aspect=aspect, slope=slope, latUnits="radians")
 
 		if(SnowDepth[i-1] > 0) TE[i] <- 0.97 	#	(-) Terrestrial Emissivity
 		if(SnowWaterEq[i-1] > 0 | NewSnowWatEq[i] > 0) {


### PR DESCRIPTION
For the SnowMelt function, the units are now defined in the call to Solar so that a warning is not displayed to the screen.

For the PotentialSolar function, an if statement is added to check for declination outside the range that will produce a result. If the declination is not within this range (i.e. high latitudes during winter), PotentialSolar is set equal to 0.